### PR TITLE
Fix error message

### DIFF
--- a/lib/handle-post-change.php
+++ b/lib/handle-post-change.php
@@ -91,7 +91,7 @@ function send_update() {
 		$msg = "There was an error, this error should be overwritten by the real error";
 		if ( is_wp_error( $response ) ) {
 			$msg = $response->get_error_message();
-		} else if ( $status_code !== 200 ){
+		} else {
 			$body = wp_remote_retrieve_body( $response );
 			$msg = $status_code . '\n' . $body;
 		}

--- a/lib/handle-post-change.php
+++ b/lib/handle-post-change.php
@@ -78,16 +78,24 @@ function send_update() {
 
 	do_action('valu_search_live_update_result', $response);
 
-	if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+	if ( ! can_see_status_messages() ) {
+		return;
+	}
+
+	$status_code = wp_remote_retrieve_response_code( $response );
+
+	if ( 200 === $status_code ) {
 		$msg = 'Search index update success!';
 		$status = 'success';
 	} else {
-		$msg = $response->get_error_message();
+		$msg = "There was an error, this error should be overwritten by the real error";
+		if ( is_wp_error( $response ) ) {
+			$msg = $response->get_error_message();
+		} else if ( $status_code !== 200 ){
+			$body = wp_remote_retrieve_body( $response );
+			$msg = $status_code . '\n' . $body;
+		}
 		$status = 'error';
-	}
-
-	if ( ! can_see_status_messages() ) {
-		return;
 	}
 
 	enqueue_flash_message( $msg, $status );


### PR DESCRIPTION
`->get_error_message()`
fails when the response is not WP_error.
Check that response is wp error before using get_error_message.

Also move early to be more early. No reason to check for error message if the message is not send anywhere.