### PR TITLE
Upgrade wp-valu-search to 0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ There's a filter for controlling the update process
 
 ### `valu_search_should_update`
 
--   `$should_update` (boolean) defaults to true
+Parameters
+
+-   `$should_update` (boolean) defaults to value of `php_sapi_name() !== 'cli'`
 -   `$post` (WP_Post) the post of the page being updated
 
 Return false to prevent the page from being updated.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "valu/wp-valu-search",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "WordPress plugin for Valu Search",
   "type": "wordpress-plugin",
   "license": "GPL-3.0-or-later",

--- a/lib/handle-post-change.php
+++ b/lib/handle-post-change.php
@@ -47,7 +47,7 @@ function send_update() {
 
 	$url_array = array();
 	foreach ( $valu_search_pending_update_array as $url => $post ) {
-		$should_update = apply_filters( 'valu_search_should_update', true, $post );
+		$should_update = apply_filters( 'valu_search_should_update', php_sapi_name() !== 'cli', $post );
 
 		if ( $should_update && 10000 > count( $url_array ) ) {
 			array_push( $url_array, $url );

--- a/valu-search.php
+++ b/valu-search.php
@@ -4,7 +4,7 @@ namespace ValuSearch;
 
 /*
 Plugin Name: Valu Search
-Version: 0.5.2
+Version: 0.5.3
 Plugin URI: https://www.valu.fi
 Description: Expose page metadata for the Search crawler
 Author: Valu Digital


### PR DESCRIPTION
Disables live updates in `cli` context by default